### PR TITLE
SIDM-1361: Updated authorize endpoint to match (best effort) tactical

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
 }
 
 
-version = '2.2.3'
+version = '2.2.4'
 group = 'uk.gov.hmcts.reform.idam'
 
 description = """idam-api-spec"""
@@ -98,6 +98,11 @@ classes.dependsOn generatedClasses
 compileJava.dependsOn compileGeneratedJava
 
 publishing {
+    repositories {
+        maven {
+            mavenLocal()
+        }
+    }
     publications {
         Main(MavenPublication) {
             from components.java

--- a/build.gradle
+++ b/build.gradle
@@ -98,11 +98,6 @@ classes.dependsOn generatedClasses
 compileJava.dependsOn compileGeneratedJava
 
 publishing {
-    repositories {
-        maven {
-            mavenLocal()
-        }
-    }
     publications {
         Main(MavenPublication) {
             from components.java

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>uk.gov.hmcts.reform.idam</groupId>
     <artifactId>idam-api-spec</artifactId>
-    <version>2.2.3</version>
+    <version>2.2.4</version>
     <packaging>jar</packaging>
 
     <parent>

--- a/src/main/resources/api.yaml
+++ b/src/main/resources/api.yaml
@@ -258,31 +258,37 @@ paths:
       produces:
         - application/json
       parameters:
-        - in: formData
-          name: username
-          description: The user's username
-          required: true
+        - in: header
+          name: Authorization
           type: string
-        - in: formData
-          name: password
-          description: The user's password
           required: true
-          type: string
+          description: "Uses Basic Authentication to identifying the principal making the request.
+          For example - `Basic dXNlcm5hbWU6cGFzc3dvcmQ=`"
         - in: formData
           name: redirect_uri
           description: "URI to redirect the user to after successful authentication. This URL
           must match one of the registered URLs for the OAuth2 application linked to the service
           initiating the authentication flow."
-          required: true
+          required: false
           type: string
         - in: formData
           name: client_id
           description: OAuth2 client id of the service initiating the OAuth2 flow.
-          required: true
+          required: false
           type: string
         - in: formData
           name: state
           description: Optional state to be sent back to the initiating service after successful authentication.
+          required: false
+          type: string
+        - in: formData
+          name: scope
+          description: Optional scopes to request.
+          required: false
+          type: string
+        - in: formData
+          name: response_type
+          description: Response type to use for this request
           required: false
           type: string
       responses:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-1361

### Change description ###
Make best effort to match Tactical IDAM's implementation of `/oauth2/authorize` when sending `response_type=code`

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```