### PR TITLE
SIDM-1563: Allow anonymous access to GET /services

### DIFF
--- a/src/main/resources/api.yaml
+++ b/src/main/resources/api.yaml
@@ -1405,6 +1405,9 @@ definitions:
       oauth2ClientId:
         type: string
         description: The Oauth2 Client Id
+      selfRegistrationAllowed:
+        type: boolean
+        description: Flag indicating whether Self-service registration is enabled for this service.
     required: [label, description, allowedRoles]
 
   ServiceUpdate:

--- a/src/main/resources/api.yaml
+++ b/src/main/resources/api.yaml
@@ -904,7 +904,6 @@ paths:
         - in: header
           name: Authorization
           type: string
-          required: true
           description: The Base64-encoded authorization token
           example: AdminApiAuthToken [api-auth-token]
       responses:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-1563

### Change description ###
Allow anonymous access to `GET /services` so that consumers (such as web-public) can lookup service information (e.g. `selfRegistrationAllowed`).  A follow-up PR could add support to query for services with a specific field, such as the `clientId`.
Also, added `selfRegistrationAllowed` to the `Service` object so that consumers can determine whether or not self-registration is permitted.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```