### PR TITLE
SIDM-3002 update idam-api-spec delete test-data

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'com.jfrog.bintray' version '1.8.4'
 }
 
-version = '2.12.2'
+version = '2.12.3'
 group = 'uk.gov.hmcts.reform.idam'
 
 description = """idam-api-spec"""

--- a/src/main/resources/internal-admin-api.yaml
+++ b/src/main/resources/internal-admin-api.yaml
@@ -1147,9 +1147,37 @@ paths:
           type: string
           required: false
           description: "Prefix for test data names"
+        - in: query
+          name: userNames
+          type: array
+          items:
+            type: string
+          required: false
+          description: "Test user names to delete"
+        - in: query
+          name: roleNames
+          type: array
+          items:
+            type: string
+          required: false
+          description: "Test role names to delete"
+        - in: query
+          name: serviceNames
+          type: array
+          items:
+            type: string
+          required: false
+          description: "Test service names to delete"
+        - in: query
+          name: async
+          type: boolean
+          required: false
+          description: "Flag to run this call asynchronously and skip waiting for its response"
       responses:
         200:
           description: "Test data deleted OK"
+          schema:
+            $ref: '#/definitions/DeletedData'
 
   /testing-support/accounts/{username:.+}:
     delete:
@@ -1668,3 +1696,70 @@ definitions:
       y:
         type: string
         description: The y coordinate for the Elliptic Curve point
+
+  DeletedData:
+    type: object
+    properties:
+      testDataPrefix:
+        type: string
+        description: Prefix for test data names requested to delete
+      userNamesRequested:
+        type: array
+        items:
+          type: string
+        description: Test user names requested to delete
+      userNamesFound:
+        type: array
+        items:
+          type: string
+        description: Test user names that matched to delete
+      userNamesDeleted:
+        type: array
+        items:
+          type: string
+        description: Test user names that succeeded to delete
+      userNamesFailed:
+        type: array
+        items:
+          type: string
+        description: Test user names that failed to delete
+      roleNamesRequested:
+        type: array
+        items:
+          type: string
+        description: Test role names requested to delete
+      roleNamesFound:
+        type: array
+        items:
+          type: string
+        description: Test role names that matched to delete
+      roleNamesDeleted:
+        type: array
+        items:
+          type: string
+        description: Test role names that succeeded to delete
+      roleNamesFailed:
+        type: array
+        items:
+          type: string
+        description: Test role names that failed to delete
+      serviceNamesRequested:
+        type: array
+        items:
+          type: string
+        description: Test service names requested to delete
+      serviceNamesFound:
+        type: array
+        items:
+          type: string
+        description: Test service names that matched to delete
+      serviceNamesDeleted:
+        type: array
+        items:
+          type: string
+        description: Test service names that succeeded to delete
+      serviceNamesFailed:
+        type: array
+        items:
+          type: string
+        description: Test service names that failed to delete


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-3002

### Change description ###
SIDM-3002 update idam-api-spec method to take a list of test data to delete and also a test prefix if needed. And delete the data in the correct order, removing this logic from tests.

SIDM-3002 update idam-api-spec delete test-data:
Add args:
- userNames, roleNames, serviceNames, async
Add return model:
- deleted data


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
